### PR TITLE
Fix indentation formatting for params with attributes

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationSource.vue
@@ -141,8 +141,9 @@ export default {
         // if we find some text ending with ", " and the next token is the start
         // of a new param, update this token text to replace the space with a
         // newline followed by 4 spaces
-        if (token.text && token.text.endsWith(', ')
-          && nextToken && nextToken.kind === TokenKind.externalParam) {
+        if (token.text && token.text.endsWith(', ') && nextToken
+          && (nextToken.kind === TokenKind.externalParam
+            || nextToken.kind === TokenKind.attribute)) {
           newToken.text = `${token.text.trimEnd()}\n${indent}`;
           indentedParams = true;
         }

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationSource.spec.js
@@ -774,4 +774,105 @@ func foobarbaz() -> Int`,
 func foo(bar: @escaping () -> ()) -> Int`,
     );
   });
+
+  it('adds newlines for params that start with attribute tokens', () => {
+    const param = name => ([
+      {
+        kind: TokenKind.externalParam,
+        text: name,
+      },
+      {
+        kind: TokenKind.text,
+        text: ': ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'Int',
+      },
+    ]);
+    const attributeParam = name => ([
+      {
+        kind: TokenKind.attribute,
+        text: '@StringBuilder',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.externalParam,
+        text: name,
+      },
+      {
+        kind: TokenKind.text,
+        text: ': () -> ',
+      },
+      {
+        kind: TokenKind.typeIdentifier,
+        text: 'String',
+      },
+    ]);
+    const tokens = (paramA, paramB) => ([
+      {
+        kind: TokenKind.keyword,
+        text: 'func',
+      },
+      {
+        kind: TokenKind.text,
+        text: ' ',
+      },
+      {
+        kind: TokenKind.identifier,
+        text: 'qux',
+      },
+      {
+        kind: TokenKind.text,
+        text: '(',
+      },
+      ...paramA,
+      {
+        kind: TokenKind.text,
+        text: ', ',
+      },
+      ...paramB,
+      {
+        kind: TokenKind.text,
+        text: ')',
+      },
+    ]);
+
+    // Before:
+    // func qux(a: Int, @StringBuilder b: () -> String)
+    //
+    // After:
+    // func qux(
+    //     a: Int,
+    //     @StringBuilder b: () -> String
+    // )
+    const wrapper = mountWithTokens(tokens(param('a'), attributeParam('b')));
+    const tokenComponents = wrapper.findAll(Token);
+    expect(getText(tokenComponents)).toBe(
+`func qux(
+    a: Int,
+    @StringBuilder b: () -> String
+)`,
+    );
+
+    // Before:
+    // func qux(@StringBuilder a: () -> String, b: Int)
+    //
+    // After:
+    // func qux(
+    //     @StringBuilder a: () -> String,
+    //     b: Int
+    // )
+    const wrapper2 = mountWithTokens(tokens(attributeParam('a'), param('b')));
+    const tokenComponents2 = wrapper2.findAll(Token);
+    expect(getText(tokenComponents2)).toBe(
+`func qux(
+    @StringBuilder a: () -> String,
+    b: Int
+)`,
+    );
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 108472125

## Summary

Fixes issue where parameters that start with attributes are not properly indented onto the next line like ones without attributes are.

Before:
```swift
// func qux(a: String, b: String, @StringBuilder c: () -> String) 
func qux(
    a: String,
    b: String, @StringBuilder c: () -> String
)
```

After:
```swift
// func qux(a: String, b: String, @StringBuilder c: () -> String)
func qux(
    a: String,
    b: String,
    @StringBuilder c: () -> String
)
```

## Dependencies

(Only due to some test refactoring done in the dependent PR—I can easily rebase things if necessary to make this an independent PR.)

https://github.com/apple/swift-docc-render/pull/633

## Testing

Steps:
1. Build this branch with `npm run build`
2. Preview example package with `env DOCC_HTML_DIR=/path/to/dist swift package --disable-sandbox preview-documentation --target [TARGET]`
3. Find/create a function with multiple parameters where one of the parameters starts with an attribute—verify that it gets indented onto its own line in the `Declaration` section when previewing the docs

Here is an example Swift package that has the example function from above (target "AttributeExamples"):
[AttributeExamples.zip](https://github.com/mportiz08/swift-docc-render/files/11400282/AttributeExamples.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary

\cc @ethan-kusters @hqhhuang @dobromir-hristov @marinaaisa