### PR TITLE
Include code as text in metadata description

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -677,6 +677,9 @@ export default {
         if (node.type === BlockType.paragraph) {
           return `${text}\n`;
         }
+        if (node.type === InlineType.codeVoice) {
+          return `${text}${node.code}`;
+        }
         if (node.type === InlineType.text) {
           return `${text}${node.text}`;
         }

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -2538,10 +2538,19 @@ describe('ContentNode', () => {
                 },
               ],
             },
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.codeVoice,
+                  code: 'C',
+                },
+              ],
+            },
           ],
         },
       });
-      expect(wrapper.vm.plaintext).toBe('A\nB');
+      expect(wrapper.vm.plaintext).toBe('A\nB\nC');
     });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: https://github.com/apple/swift-docc-render/issues/856 
Duplicates https://github.com/apple/swift-docc-render/pull/863 for DX consistency

## Summary

Fixes a bug where the logic that populates <meta name="description"> content doesn't include the code wrapped in backticks 

## Testing

1. Use a code in backticks `` `code` `` in first paragraph abstract for a documentation page.
1. Verify that the text is now included in the <meta name="description"> tag in the resulting HTML

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary - **(not necessary)**
